### PR TITLE
[0.2.0] API Performance improvements and simulations

### DIFF
--- a/api/models/counter.ts
+++ b/api/models/counter.ts
@@ -1,0 +1,40 @@
+export type TCount = { [damage: number]: number };
+
+export interface ICounter {
+  lt: TCount;
+  eq: TCount;
+  gt: TCount;
+}
+
+export class Counter implements ICounter {
+  lt: TCount;
+  eq: TCount;
+  gt: TCount;
+
+  constructor() {
+    this.lt = {};
+    this.eq = {};
+    this.gt = {};
+  }
+
+  increment(variant: keyof ICounter, damage: number) {
+    this[variant][damage] = (this[variant][damage] || 0) + 1;
+  }
+
+  incrementLt(damage: number) {
+    this.increment('lt', damage);
+  }
+
+  incrementEq(damage: number) {
+    this.increment('eq', damage);
+  }
+
+  incrementGt(damage: number) {
+    this.increment('gt', damage);
+  }
+
+  toDict(): ICounter {
+    const { lt, eq, gt } = this;
+    return { lt, eq, gt };
+  }
+}

--- a/api/models/fighter.ts
+++ b/api/models/fighter.ts
@@ -1,7 +1,7 @@
 import Combinatorics, { IPredictableGenerator } from 'js-combinatorics';
 
-import { IFighter, IFighterProbability, IProfile, ITarget, TVector } from '../types';
-import { getMax, getMean } from '../utils/statsUtils';
+import { IFighter, IFighterProbabilities, IProfile, TVector } from '../types';
+import { Counter, ICounter, TCount } from './counter';
 import { D6 } from './dice';
 
 const generatePermutations = <T>(vector: T[], n = 1): IPredictableGenerator<T[]> => {
@@ -18,16 +18,61 @@ class Fighter implements IFighter {
     this.profile = this.parseProfile(profile);
   }
 
-  getProbabilities(target: ITarget): IFighterProbability {
-    const permutations = this.getPermutationMatrix(target);
-    const numPermutations = permutations.length;
-    const counts = {};
-    let sum = 0;
-    permutations.forEach(vector => {
-      const result = vector.reduce((acc, point) => acc + point, 0);
-      sum += result;
-      counts[result] = (counts[result] || 0) + 1;
+  getProbabilities(): IFighterProbabilities {
+    const permutationGenerator = this.getDicePermutationMatrix();
+    const numPermutations = permutationGenerator.length;
+    const counts = this.getDamageCounts(permutationGenerator);
+    const metrics = this.getMetrics();
+    const buckets = {
+      lt: this.getBuckets(counts.lt, numPermutations, metrics.lt.max),
+      eq: this.getBuckets(counts.eq, numPermutations, metrics.eq.max),
+      gt: this.getBuckets(counts.gt, numPermutations, metrics.gt.max),
+    };
+    return {
+      lt: { buckets: buckets.lt, metrics: metrics.lt },
+      eq: { buckets: buckets.eq, metrics: metrics.eq },
+      gt: { buckets: buckets.gt, metrics: metrics.gt },
+    };
+  }
+
+  private getDamageCounts(permutationGenerator: IPredictableGenerator<TVector>): ICounter {
+    const counts = new Counter();
+    permutationGenerator.forEach((vector: TVector) => {
+      counts.incrementLt(this.reduceVector(vector, 5));
+      counts.incrementEq(this.reduceVector(vector, 4));
+      counts.incrementGt(this.reduceVector(vector, 3));
     });
+    return counts.toDict();
+  }
+
+  private reduceVector(vector: TVector, rollTarget: 3 | 4 | 5): number {
+    return vector.reduce((acc, roll) => {
+      const { hit, crit } = this.profile.damage;
+      if (roll >= 6) return acc + crit;
+      if (roll >= rollTarget) return acc + hit;
+      return acc;
+    }, 0);
+  }
+
+  private getMetrics() {
+    const { attacks, damage } = this.profile;
+    const max = attacks * damage.crit;
+    return {
+      lt: { max, mean: this.getMean(5) },
+      eq: { max, mean: this.getMean(4) },
+      gt: { max, mean: this.getMean(3) },
+    };
+  }
+
+  private getMean(rollTarget: 3 | 4 | 5) {
+    const { attacks, damage } = this.profile;
+    const hitChance = (D6.sides - rollTarget) / D6.sides;
+    const critChance = 1 / D6.sides;
+    const mean = attacks * (hitChance * damage.hit + critChance * damage.crit);
+    return Number(mean.toFixed(2));
+  }
+
+  private getBuckets(counts: TCount, numPermutations: number, max: number) {
     const buckets = Object.keys(counts)
       .map(Number)
       .sort((x, y) => x - y)
@@ -36,45 +81,13 @@ class Fighter implements IFighter {
         count: counts[damage],
         probability: Number(((counts[damage] * 100) / numPermutations).toFixed(2)),
       }));
-    const metrics = {
-      max: getMax(Object.keys(counts).map(Number)),
-      mean: Number((sum / numPermutations).toFixed(2)),
-    };
-    buckets.push({ damage: metrics.max + 1, count: 0, probability: 0 });
-    return {
-      buckets,
-      metrics,
-    };
-  }
-
-  getReducedPermutations(target: ITarget): TVector {
-    return this.getPermutationMatrix(target).map(vector => vector.reduce((acc, point) => acc + point, 0));
-  }
-
-  getPermutationMatrix(target: ITarget): IPredictableGenerator<TVector> {
-    const { attacks, damage } = this.profile;
-    const { hit, crit } = damage;
-    const rollVector = D6.getRollVector();
-    const rollTarget = this.getRollTarget(target);
-    const resultVector = rollVector.map(roll => {
-      if (roll === 6) return crit;
-      if (roll >= rollTarget) return hit;
-      return 0;
-    });
-    return generatePermutations(resultVector, attacks);
+    buckets.push({ damage: max + 1, count: 0, probability: 0 });
+    return buckets;
   }
 
   getDicePermutationMatrix(): IPredictableGenerator<TVector> {
     const { attacks } = this.profile;
     return generatePermutations(D6.getRollVector(), attacks);
-  }
-
-  getRollTarget(target: ITarget): number {
-    const { strength } = this.profile;
-    const { toughness } = target;
-    if (strength > toughness) return 3;
-    if (strength === toughness) return 4;
-    return 5;
   }
 
   private parseProfile(profile: IProfile): IProfile {

--- a/api/models/generator.ts
+++ b/api/models/generator.ts
@@ -1,3 +1,6 @@
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
+
 import { TVector } from 'api/types';
 import { IGenerator } from 'js-combinatorics';
 

--- a/api/models/generator.ts
+++ b/api/models/generator.ts
@@ -1,0 +1,75 @@
+import { TVector } from 'api/types';
+import { IGenerator } from 'js-combinatorics';
+
+import { D6 } from './dice';
+
+class SimulationGenerator implements IGenerator<TVector> {
+  private generator: Generator<TVector, void, unknown>;
+  private numSimulations: number;
+  private numAttacks: number;
+  length: number;
+
+  constructor(numSimulations: number, numAttacks: number) {
+    this.numSimulations = numSimulations;
+    this.length = numSimulations;
+    this.numAttacks = numAttacks;
+    this.init();
+  }
+
+  next(): TVector {
+    const n = this.generator.next();
+    if (n.done) return undefined;
+    return n.value as TVector;
+  }
+
+  forEach(f: (item: TVector) => void): void {
+    this.init();
+    let n = this.next();
+    while (n) {
+      f(n);
+      n = this.next();
+    }
+    this.init();
+  }
+
+  map<TResult>(f: (item: TVector) => TResult): TResult[] {
+    return this.toArray().map(f);
+  }
+
+  filter(predicate: (item: TVector) => boolean): TVector[] {
+    this.init();
+    let n = this.next();
+    const result = [];
+    while (n) {
+      if (predicate(n)) result.push(n);
+      n = this.next();
+    }
+    this.init();
+    return result;
+  }
+
+  toArray() {
+    this.init();
+    let n = this.next();
+    const result = [];
+    while (n) {
+      result.push(n);
+      n = this.next();
+    }
+    this.init();
+    return result;
+  }
+
+  private init() {
+    this.generator = this.createGen();
+  }
+
+  private *createGen(): Generator<TVector, undefined, TVector> {
+    for (let i = 0; i < this.numSimulations; i += 1) {
+      yield [...Array(this.numAttacks)].map(() => D6.roll());
+    }
+    return undefined;
+  }
+}
+
+export default SimulationGenerator;

--- a/api/tests/fighter.test.ts
+++ b/api/tests/fighter.test.ts
@@ -11,123 +11,112 @@ const testProfile = {
 const testFighter = new Fighter('Test', testProfile);
 
 describe('Fighter', () => {
-  describe('Constructor', () => {
-    test('Correctly casts bad types', () => {
-      const badProfile = {
-        attacks: '2',
-        strength: '4',
-        damage: {
-          hit: '1',
-          crit: '2',
-        },
-      };
-      // @ts-ignore
-      const fighter = new Fighter('Test', badProfile);
-      expect(fighter.name).toBe('Test');
-      expect(fighter.profile).toEqual(testProfile);
-    });
+  test('Constructor', () => {
+    const badProfile = {
+      attacks: '2',
+      strength: '4',
+      damage: {
+        hit: '1',
+        crit: '2',
+      },
+    };
+    // @ts-ignore
+    const fighter = new Fighter('Test', badProfile);
+    expect(fighter.name).toBe('Test');
+    expect(fighter.profile).toEqual(testProfile);
   });
 
-  describe('Roll Target', () => {
-    test('Strength < Toughness', () => {
-      expect(testFighter.getRollTarget({ toughness: 5 })).toEqual(5);
-    });
-    test('Strength = Toughness', () => {
-      expect(testFighter.getRollTarget({ toughness: 4 })).toEqual(4);
-    });
-    test('Strength > Toughness', () => {
-      expect(testFighter.getRollTarget({ toughness: 3 })).toEqual(3);
-    });
-  });
-
-  test('Get Permutation Matrix', () => {
-    /* Working:
-    Roll Vector: [1, 2, 3, 4, 5, 6]
-    Roll Target: 4
-    Result Vector: [0, 0, 0, 1, 1, 2] */
+  test('Dice Permutation Matrix', () => {
+    // Roll Vector: [1, 2, 3, 4, 5, 6]
+    // prettier-ignore
     const permutations = [
-      [0, 0],
-      [0, 0],
-      [0, 0],
-      [0, 1],
-      [0, 1],
-      [0, 2],
-      [0, 0],
-      [0, 0],
-      [0, 0],
-      [0, 1],
-      [0, 1],
-      [0, 2],
-      [0, 0],
-      [0, 0],
-      [0, 0],
-      [0, 1],
-      [0, 1],
-      [0, 2],
-      [1, 0],
-      [1, 0],
-      [1, 0],
-      [1, 1],
-      [1, 1],
-      [1, 2],
-      [1, 0],
-      [1, 0],
-      [1, 0],
-      [1, 1],
-      [1, 1],
-      [1, 2],
-      [2, 0],
-      [2, 0],
-      [2, 0],
-      [2, 1],
-      [2, 1],
-      [2, 2],
+      [1, 1], [1, 2], [1, 3], [1, 4], [1, 5], [1, 6],
+      [2, 1], [2, 2], [2, 3], [2, 4], [2, 5], [2, 6],
+      [3, 1], [3, 2], [3, 3], [3, 4], [3, 5], [3, 6],
+      [4, 1], [4, 2], [4, 3], [4, 4], [4, 5], [4, 6],
+      [5, 1], [5, 2], [5, 3], [5, 4], [5, 5], [5, 6],
+      [6, 1], [6, 2], [6, 3], [6, 4], [6, 5], [6, 6],
     ];
     expect(
       testFighter
-        .getPermutationMatrix({ toughness: 4 })
+        .getDicePermutationMatrix()
         .toArray()
         .sort(),
     ).toEqual(permutations.sort());
   });
 
-  test('Get Reduced Permutations', () => {
-    /* Working:
-      - 3 repeats of sequence 0, 0, 0, 1, 1, 2
-      - 2 repeats of sequence 1, 1, 1, 2, 2, 3
-      - 1 repeat of sequence 2, 2, 2, 3, 3, 4
-    */
-    const getRepeatedSequence = (sequence: number[], repeats: number): number[] =>
-      Array(repeats)
-        .fill(sequence)
-        .flat();
-
-    const reducedPermutations = [
-      ...getRepeatedSequence([0, 0, 0, 1, 1, 2], 3),
-      ...getRepeatedSequence([1, 1, 1, 2, 2, 3], 2),
-      ...getRepeatedSequence([2, 2, 2, 3, 3, 4], 1),
-    ];
-    expect(testFighter.getReducedPermutations({ toughness: 4 }).sort()).toEqual(reducedPermutations.sort());
-  });
-
-  test('Get Probabilities', () => {
-    const expected = {
-      buckets: [
-        { damage: 0, count: 9, probability: 25 },
-        { damage: 1, count: 12, probability: 33.33 },
-        { damage: 2, count: 10, probability: 27.78 },
-        { damage: 3, count: 4, probability: 11.11 },
-        { damage: 4, count: 1, probability: 2.78 },
-        { damage: 5, count: 0, probability: 0 },
-      ],
-      // Total: 48
-      metrics: {
-        max: 4,
-        mean: 1.33,
-      },
-    };
-    const output = testFighter.getProbabilities({ toughness: 4 });
-    expect(output.buckets).toEqual(expected.buckets);
-    expect(output.metrics).toEqual(expected.metrics);
+  describe('Get Probabilities', () => {
+    test('Strength < Toughness', () => {
+      /* Working:
+        - 4 repeats of sequence 0, 0, 0, 0, 1, 2
+        - 1 repeats of sequence 1, 1, 1, 1, 2, 3
+        - 1 repeat of sequence 2, 2, 2, 2, 3, 4
+      */
+      const expected = {
+        buckets: [
+          { damage: 0, count: 16, probability: 44.44 },
+          { damage: 1, count: 8, probability: 22.22 },
+          { damage: 2, count: 9, probability: 25 },
+          { damage: 3, count: 2, probability: 5.56 },
+          { damage: 4, count: 1, probability: 2.78 },
+          { damage: 5, count: 0, probability: 0 },
+        ],
+        metrics: {
+          max: 4,
+          mean: 1,
+        },
+      };
+      const output = testFighter.getProbabilities();
+      expect(output.lt.buckets).toEqual(expected.buckets);
+      expect(output.lt.metrics).toEqual(expected.metrics);
+    });
+    test('Strength = Toughness', () => {
+      /* Working:
+        - 3 repeats of sequence 0, 0, 0, 1, 1, 2
+        - 2 repeats of sequence 1, 1, 1, 2, 2, 3
+        - 1 repeat of sequence 2, 2, 2, 3, 3, 4
+      */
+      const expected = {
+        buckets: [
+          { damage: 0, count: 9, probability: 25 },
+          { damage: 1, count: 12, probability: 33.33 },
+          { damage: 2, count: 10, probability: 27.78 },
+          { damage: 3, count: 4, probability: 11.11 },
+          { damage: 4, count: 1, probability: 2.78 },
+          { damage: 5, count: 0, probability: 0 },
+        ],
+        metrics: {
+          max: 4,
+          mean: 1.33,
+        },
+      };
+      const output = testFighter.getProbabilities();
+      expect(output.eq.buckets).toEqual(expected.buckets);
+      expect(output.eq.metrics).toEqual(expected.metrics);
+    });
+    test('Strength > Toughness', () => {
+      /* Working:
+        - 2 repeats of sequence 0, 0, 1, 1, 1, 2
+        - 3 repeats of sequence 1, 1, 2, 2, 2, 3
+        - 1 repeat of sequence 2, 2, 3, 3, 3, 4
+      */
+      const expected = {
+        buckets: [
+          { damage: 0, count: 4, probability: 11.11 },
+          { damage: 1, count: 12, probability: 33.33 },
+          { damage: 2, count: 13, probability: 36.11 },
+          { damage: 3, count: 6, probability: 16.67 },
+          { damage: 4, count: 1, probability: 2.78 },
+          { damage: 5, count: 0, probability: 0 },
+        ],
+        metrics: {
+          max: 4,
+          mean: 1.67,
+        },
+      };
+      const output = testFighter.getProbabilities();
+      expect(output.gt.buckets).toEqual(expected.buckets);
+      expect(output.gt.metrics).toEqual(expected.metrics);
+    });
   });
 });

--- a/api/types.ts
+++ b/api/types.ts
@@ -32,3 +32,9 @@ export interface IFighterProbability {
     mean: number;
   };
 }
+
+export interface IFighterProbabilities {
+  lt: IFighterProbability;
+  eq: IFighterProbability;
+  gt: IFighterProbability;
+}

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "warcry-statshammer-client",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "proxy": "http://localhost:5000",
   "dependencies": {

--- a/client/src/appConfig.ts
+++ b/client/src/appConfig.ts
@@ -2,7 +2,7 @@ const appConfig = {
   limits: {
     fighters: 8,
     profiles: 5,
-    maxAttacks: 8,
+    maxAttacks: 15,
   },
 };
 

--- a/client/src/components/AppBar/AppBar.tsx
+++ b/client/src/components/AppBar/AppBar.tsx
@@ -1,4 +1,12 @@
-import { AppBar as Bar, IconButton, Slide, Toolbar, Typography, useScrollTrigger } from '@material-ui/core';
+import {
+  AppBar as Bar,
+  IconButton,
+  Slide,
+  Toolbar,
+  Typography,
+  useScrollTrigger,
+  useTheme,
+} from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import { BrightnessMedium as BrightnessMediumIcon } from '@material-ui/icons';
 import Link from 'components/Link';
@@ -14,6 +22,10 @@ interface IStyleProps {
 const useStyles = makeStyles((theme: Theme) => ({
   appBar: {
     background: theme.palette.primary.dark,
+    [theme.breakpoints.up('md')]: {
+      marginLeft: theme.mixins.drawer.width,
+      width: `calc(100% - ${theme.mixins.drawer.width}px)`,
+    },
   },
   offset: ({ height }: IStyleProps) => ({
     marginTop: height,
@@ -52,7 +64,7 @@ const AppBar = () => {
   return (
     <div>
       <Slide appear={false} direction="down" in={!trigger}>
-        <Bar className={classes.appBar}>
+        <Bar className={classes.appBar} position="fixed">
           <div ref={ref}>
             <Toolbar variant="dense" className={classes.toolbar}>
               <Link to={getRoute(EPages.HOME)}>

--- a/client/src/components/AppBar/AppBar.tsx
+++ b/client/src/components/AppBar/AppBar.tsx
@@ -1,12 +1,4 @@
-import {
-  AppBar as Bar,
-  IconButton,
-  Slide,
-  Toolbar,
-  Typography,
-  useScrollTrigger,
-  useTheme,
-} from '@material-ui/core';
+import { AppBar as Bar, IconButton, Slide, Toolbar, Typography, useScrollTrigger } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import { BrightnessMedium as BrightnessMediumIcon } from '@material-ui/icons';
 import Link from 'components/Link';

--- a/client/src/components/LeftNavigation/LeftNavigation.tsx
+++ b/client/src/components/LeftNavigation/LeftNavigation.tsx
@@ -1,6 +1,9 @@
-import { Tab, Tabs } from '@material-ui/core';
+import { Divider, Drawer, Tab, Tabs } from '@material-ui/core';
 import { makeStyles, Theme } from '@material-ui/core/styles';
 import { BarChart as StatsIcon, Home as HomeIcon, Info as InfoIcon } from '@material-ui/icons';
+import Link from 'components/Link';
+import Logo from 'components/Logo';
+import Version from 'components/Version';
 import { useRouteFind } from 'hooks';
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
@@ -10,13 +13,27 @@ import { IStore } from 'types/store';
 
 const useStyles = makeStyles((theme: Theme) => ({
   leftNavigation: {
+    width: theme.mixins.drawer.width,
     [theme.breakpoints.down('sm')]: {
       display: 'none',
     },
   },
+  drawer: {
+    width: theme.mixins.drawer.width,
+  },
+  drawerLogo: {
+    padding: theme.spacing(0.5),
+    width: theme.mixins.drawer.width,
+    textAlign: 'center',
+  },
+  caption: {
+    textAlign: 'end',
+    padding: theme.spacing(1),
+  },
   tabs: {
     borderRight: `1px solid ${theme.palette.divider}`,
     height: '100%',
+    width: theme.mixins.drawer.width,
   },
 }));
 
@@ -36,26 +53,34 @@ const LeftNavigation = () => {
 
   const handleChange = (event: any, newValue: number) => {
     setIndex(newValue);
-    // This is done so that the indicator can finish moving before loading the next page
-    // This ensures that the animation is smooth
-    setTimeout(() => {
-      history.push(routes[newValue]);
-    }, 120);
+    history.push(routes[newValue]);
   };
 
   return (
     <div className={classes.leftNavigation}>
-      <Tabs
-        orientation="vertical"
-        value={index}
-        onChange={handleChange}
-        className={classes.tabs}
-        indicatorColor="primary"
-      >
-        <Tab label="Home" icon={<HomeIcon />} />
-        <Tab label="Stats" icon={<StatsIcon />} disabled={numFighters <= 0} />
-        <Tab label="About" icon={<InfoIcon />} />
-      </Tabs>
+      <Drawer open variant="permanent" anchor="left" className={classes.drawer}>
+        <Link to={getRoute(EPages.HOME)} className={classes.drawerLogo}>
+          <Logo height={60} />
+        </Link>
+        <Divider variant="middle" />
+        <Tabs
+          orientation="vertical"
+          value={index}
+          onChange={handleChange}
+          className={classes.tabs}
+          indicatorColor="primary"
+          textColor="primary"
+          variant="fullWidth"
+          TabIndicatorProps={{
+            style: { display: 'none' },
+          }}
+        >
+          <Tab label="Home" icon={<HomeIcon />} />
+          <Tab label="Stats" icon={<StatsIcon />} disabled={numFighters <= 0} />
+          <Tab label="About" icon={<InfoIcon />} />
+        </Tabs>
+        <Version includePrefixText={false} />
+      </Drawer>
     </div>
   );
 };

--- a/client/src/components/Logo/Logo.tsx
+++ b/client/src/components/Logo/Logo.tsx
@@ -2,24 +2,29 @@ import { Icon } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import React from 'react';
 
-type IStyleProps = { fontSize: number };
+type IStyleProps = { width: number | string | 'auto'; height: number | string | 'auto' };
 const useStyles = makeStyles(() => ({
   logo: (props: IStyleProps) => ({
-    fontSize: `${props.fontSize}rem`,
+    textAlign: 'center',
+    width: props.width,
+    height: props.height,
   }),
-  icon: {
-    height: '100%',
-  },
+  icon: (props: IStyleProps) => ({
+    maxWidth: '100%',
+    height: props.height,
+  }),
 }));
 
 interface ILogoProps {
-  fontSize?: number;
+  width?: number | string | 'auto';
+  height?: number | string | 'auto';
+  className?: string;
 }
-const Logo = ({ fontSize = 7 }: ILogoProps) => {
-  const classes = useStyles({ fontSize });
+const Logo = ({ width = 'auto', height = 'auto', className }: ILogoProps) => {
+  const classes = useStyles({ width, height });
 
   return (
-    <Icon className={classes.logo}>
+    <Icon className={className} classes={{ root: classes.logo }}>
       <img src="/logo.svg" alt="Warcry Statshammer" className={classes.icon} />
     </Icon>
   );

--- a/client/src/components/Version/Version.tsx
+++ b/client/src/components/Version/Version.tsx
@@ -1,0 +1,33 @@
+import { Typography } from '@material-ui/core';
+import { grey } from '@material-ui/core/colors';
+import { makeStyles, Theme } from '@material-ui/core/styles';
+import React from 'react';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  version: {
+    padding: theme.spacing(1),
+    display: 'flex',
+    justifyContent: 'flex-end',
+    color: grey[500],
+  },
+}));
+
+interface IVersionProps {
+  className?: string;
+  includePrefixText?: boolean;
+}
+const Version = ({ className, includePrefixText = true }: IVersionProps) => {
+  const classes = useStyles();
+
+  return (
+    <div className={className}>
+      {process.env.REACT_APP_VERSION && (
+        <Typography variant="caption" className={classes.version}>
+          {`${includePrefixText ? 'Current Version: ' : ''}v${process.env.REACT_APP_VERSION}`}
+        </Typography>
+      )}
+    </div>
+  );
+};
+
+export default Version;

--- a/client/src/components/Version/index.tsx
+++ b/client/src/components/Version/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './Version';

--- a/client/src/containers/About/About.tsx
+++ b/client/src/containers/About/About.tsx
@@ -3,6 +3,7 @@ import { grey } from '@material-ui/core/colors';
 import { makeStyles } from '@material-ui/core/styles';
 import Logo from 'components/Logo';
 import { Github, Reddit, Releases } from 'components/SocialButtons';
+import Version from 'components/Version';
 import { useReadFromFile } from 'hooks';
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
@@ -53,11 +54,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   spacer: {
     flex: 1,
   },
-  version: {
-    display: 'flex',
-    justifyContent: 'flex-end',
-    color: grey[500],
-  },
   socialButton: {
     margin: theme.spacing(1),
   },
@@ -77,7 +73,7 @@ const About = () => {
       <div className={classes.wrapper}>
         <Paper className={classes.paper}>
           <IconButton onClick={handleLogoClick} className={classes.logoButton}>
-            <Logo fontSize={7} />
+            <Logo width="7rem" />
           </IconButton>
           {!content && (
             <div className={classes.loader}>
@@ -94,11 +90,7 @@ const About = () => {
           </div>
           <div className={classes.spacer} />
           <Divider className={classes.divider} />
-          {process.env.REACT_APP_VERSION && (
-            <Typography variant="caption" className={classes.version}>
-              {`Current Version: v${process.env.REACT_APP_VERSION}`}
-            </Typography>
-          )}
+          <Version />
         </Paper>
       </div>
     </div>

--- a/client/src/containers/About/About.tsx
+++ b/client/src/containers/About/About.tsx
@@ -1,5 +1,4 @@
 import { CircularProgress, Divider, IconButton, Paper, Theme, Typography } from '@material-ui/core';
-import { grey } from '@material-ui/core/colors';
 import { makeStyles } from '@material-ui/core/styles';
 import Logo from 'components/Logo';
 import { Github, Reddit, Releases } from 'components/SocialButtons';

--- a/client/src/containers/App/App.tsx
+++ b/client/src/containers/App/App.tsx
@@ -10,7 +10,7 @@ import Stats from 'containers/Stats';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { BrowserRouter as Router, Redirect, Route, Switch } from 'react-router-dom';
-import getTheme from 'themes';
+import { getTheme } from 'themes';
 import { EPages, getRoute } from 'types/routes';
 import { IStore } from 'types/store';
 
@@ -21,6 +21,17 @@ const useStyles = makeStyles((theme: Theme) => ({
     minHeight: '100vh',
     justifyContent: 'center',
   },
+  inner: {
+    display: 'flex',
+    flexDirection: 'row',
+    flex: 1,
+    width: '100%',
+  },
+  contentWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    width: '100%',
+  },
   content: {
     display: 'flex',
     flexDirection: 'column',
@@ -29,12 +40,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     flex: 1,
     width: '100%',
     maxWidth: 1600,
-  },
-  inner: {
-    display: 'flex',
-    flexDirection: 'row',
-    flex: 1,
-    width: '100%',
   },
 }));
 
@@ -49,16 +54,18 @@ const App = () => {
           <AppBar />
           <div className={classes.inner}>
             <LeftNavigation />
-            <div className={classes.content}>
-              <Switch>
-                <Route exact path={getRoute(EPages.HOME)} component={Home} />
-                <Route exact path={getRoute(EPages.STATS)} component={Stats} />
-                <Route exact path={getRoute(EPages.ABOUT)} component={About} />
-                <Redirect to={getRoute(EPages.HOME)} />
-              </Switch>
+            <div className={classes.contentWrapper}>
+              <div className={classes.content}>
+                <Switch>
+                  <Route exact path={getRoute(EPages.HOME)} component={Home} />
+                  <Route exact path={getRoute(EPages.STATS)} component={Stats} />
+                  <Route exact path={getRoute(EPages.ABOUT)} component={About} />
+                  <Redirect to={getRoute(EPages.HOME)} />
+                </Switch>
+              </div>
+              <Footer />
             </div>
           </div>
-          <Footer />
           <BottomNavigation />
         </div>
       </ThemeProvider>

--- a/client/src/containers/Stats/Loader.tsx
+++ b/client/src/containers/Stats/Loader.tsx
@@ -12,14 +12,17 @@ const useStyles = makeStyles((theme: Theme) => ({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  circle: {
+    marginBottom: theme.spacing(3),
+  },
 }));
 
 const Loader = () => {
   const classes = useStyles();
   return (
     <Paper className={classes.loader}>
-      <CircularProgress size={92} />
-      <Typography variant="h6">Loading...</Typography>
+      <CircularProgress size={92} disableShrink className={classes.circle} />
+      <Typography variant="h6">Loading</Typography>
     </Paper>
   );
 };

--- a/client/src/tests/warbands/jest.d.ts
+++ b/client/src/tests/warbands/jest.d.ts
@@ -1,0 +1,5 @@
+declare namespace jest {
+  interface Matchers<R> {
+    toHaveOneActiveProfile(): CustomMatcherResult;
+  }
+}

--- a/client/src/tests/warbands/jest.d.ts
+++ b/client/src/tests/warbands/jest.d.ts
@@ -1,5 +1,6 @@
 declare namespace jest {
   interface Matchers<R> {
     toHaveOneActiveProfile(): CustomMatcherResult;
+    toBeValidProfile(): CustomMatcherResult;
   }
 }

--- a/client/src/tests/warbands/warbands.test.ts
+++ b/client/src/tests/warbands/warbands.test.ts
@@ -1,0 +1,41 @@
+import { IFighter } from 'types/fighter';
+import warbands from 'warbands';
+
+expect.extend({
+  toHaveOneActiveProfile(received: IFighter) {
+    const pass = received.profiles.filter(i => i.active).length === 1;
+    if (pass) {
+      return {
+        message: () => `expected ${received?.name ?? 'Fighter'} to not have 1 active profile`,
+        pass: true,
+      };
+    }
+    return {
+      message: () => `expected ${received?.name ?? 'Fighter'} to have only 1 active profile`,
+      pass: false,
+    };
+  },
+});
+
+describe('Warbands', () => {
+  warbands.forEach((warband, index) => {
+    describe(`${warband?.name ?? index}`, () => {
+      test('Metadata', () => {
+        expect(typeof warband.name).toBe('string');
+        expect(['Chaos', 'Death', 'Destruction', 'Order']).toContain(warband.alliance);
+        expect(typeof warband.isAos).toBe('boolean');
+      });
+
+      describe('Fighters', () => {
+        expect(warband.fighters.length).toBeGreaterThan(0);
+        warband.fighters.forEach((fighter, fighterIndex) => {
+          test(`${fighter?.name ?? fighterIndex}`, () => {
+            expect(typeof fighter.name).toBe('string');
+            expect(fighter.profiles.length).toBeGreaterThan(0);
+            expect(fighter).toHaveOneActiveProfile();
+          });
+        });
+      });
+    });
+  });
+});

--- a/client/src/tests/warbands/warbands.test.ts
+++ b/client/src/tests/warbands/warbands.test.ts
@@ -1,18 +1,26 @@
-import { IFighter } from 'types/fighter';
+import { IFighter, IProfile } from 'types/fighter';
 import warbands from 'warbands';
 
 expect.extend({
   toHaveOneActiveProfile(received: IFighter) {
     const pass = received.profiles.filter(i => i.active).length === 1;
-    if (pass) {
-      return {
-        message: () => `expected ${received?.name ?? 'Fighter'} to not have 1 active profile`,
-        pass: true,
-      };
-    }
     return {
       message: () => `expected ${received?.name ?? 'Fighter'} to have only 1 active profile`,
-      pass: false,
+      pass,
+    };
+  },
+  toBeValidProfile(received: IProfile) {
+    const pass =
+      typeof received.active === 'boolean' &&
+      (typeof received.range === 'number' || typeof received.range === 'string') &&
+      typeof received.attacks === 'number' &&
+      typeof received.strength === 'number' &&
+      typeof received.damage === 'object' &&
+      typeof received.damage.hit === 'number' &&
+      typeof received.damage.crit === 'number';
+    return {
+      message: () => `expected ${JSON.stringify(received)} to be a valid fighter profile`,
+      pass,
     };
   },
 });
@@ -33,6 +41,9 @@ describe('Warbands', () => {
             expect(typeof fighter.name).toBe('string');
             expect(fighter.profiles.length).toBeGreaterThan(0);
             expect(fighter).toHaveOneActiveProfile();
+            fighter.profiles.forEach(profile => {
+              expect(profile).toBeValidProfile();
+            });
           });
         });
       });

--- a/client/src/themes.ts
+++ b/client/src/themes.ts
@@ -1,8 +1,29 @@
 import { amber, green, grey, red, teal } from '@material-ui/core/colors';
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createMuiTheme, Theme } from '@material-ui/core/styles';
 import { IConfigStore } from 'types/store';
 
-const lightTheme = createMuiTheme({
+const commonOptions = {
+  mixins: {
+    drawer: {
+      width: 160,
+    },
+  },
+  typography: {
+    htmlFontSize: 20,
+    h6: {
+      fontSize: '1rem',
+    },
+  },
+  overrides: {
+    MuiTooltip: {
+      tooltip: {
+        fontSize: '0.8rem',
+      },
+    },
+  },
+};
+
+export const lightTheme: Theme = createMuiTheme({
   name: 'Light Theme',
   palette: {
     type: 'light',
@@ -31,22 +52,10 @@ const lightTheme = createMuiTheme({
       error: red[500],
     },
   },
-  typography: {
-    htmlFontSize: 18,
-    h6: {
-      fontSize: '1rem',
-    },
-  },
-  overrides: {
-    MuiTooltip: {
-      tooltip: {
-        fontSize: '0.8rem',
-      },
-    },
-  },
+  ...commonOptions,
 });
 
-const darkTheme = createMuiTheme({
+export const darkTheme: Theme = createMuiTheme({
   name: 'Dark Theme',
   palette: {
     type: 'dark',
@@ -75,21 +84,9 @@ const darkTheme = createMuiTheme({
       error: red[800],
     },
   },
-  typography: {
-    htmlFontSize: 18,
-    h6: {
-      fontSize: '1rem',
-    },
-  },
-  overrides: {
-    MuiTooltip: {
-      tooltip: {
-        fontSize: '0.8rem',
-      },
-    },
-  },
+  ...commonOptions,
 });
 
-const getTheme = (config: IConfigStore) => (config.darkMode ? darkTheme : lightTheme);
+export const getTheme = (config: IConfigStore) => (config.darkMode ? darkTheme : lightTheme);
 
-export { lightTheme, darkTheme, getTheme as default };
+export default getTheme;

--- a/client/src/types/fighter.ts
+++ b/client/src/types/fighter.ts
@@ -6,7 +6,7 @@ export interface IDamage {
 export interface IProfile {
   active: boolean;
   uuid?: string;
-  range?: number;
+  range?: string | number;
   attacks: number;
   strength: number;
   damage: IDamage;

--- a/client/src/types/theming/createMixins.d.ts
+++ b/client/src/types/theming/createMixins.d.ts
@@ -1,0 +1,14 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import createMixins from '@material-ui/core/styles/createMixins';
+
+declare module '@material-ui/core/styles/createMixins' {
+  interface CustomMixins {
+    drawer: {
+      width: number
+    }
+  }
+
+  interface MixinsOptions extends CustomMixins {}
+
+  interface Mixins extends CustomMixins {}
+}

--- a/client/src/types/theming/createMixins.d.ts
+++ b/client/src/types/theming/createMixins.d.ts
@@ -4,8 +4,8 @@ import createMixins from '@material-ui/core/styles/createMixins';
 declare module '@material-ui/core/styles/createMixins' {
   interface CustomMixins {
     drawer: {
-      width: number
-    }
+      width: number;
+    };
   }
 
   interface MixinsOptions extends CustomMixins {}

--- a/client/src/warbands/IronGolems.ts
+++ b/client/src/warbands/IronGolems.ts
@@ -1,0 +1,48 @@
+import { buildProfile } from './utils';
+import { IWarband } from './warbands.types';
+
+const IronGolems: IWarband = {
+  name: 'Iron Golems',
+  alliance: 'Chaos',
+  isAos: false,
+  fighters: [
+    {
+      name: 'Dominar',
+      profiles: [buildProfile(true, 1, 2, 5, 2, 5)],
+    },
+    {
+      name: 'Ogre Breacher',
+      profiles: [buildProfile(true, 1, 2, 6, 4, 8)],
+    },
+    {
+      name: 'Signifer',
+      profiles: [buildProfile(true, 1, 3, 4, 2, 4)],
+    },
+    {
+      name: 'Drillmaster',
+      profiles: [buildProfile(true, 1, 4, 4, 2, 4), buildProfile(false, 3, 4, 4, 1, 2)],
+    },
+    {
+      name: 'Prefector',
+      profiles: [buildProfile(true, 1, 3, 4, 2, 5)],
+    },
+    {
+      name: 'Armator',
+      profiles: [buildProfile(true, 1, 4, 4, 1, 4)],
+    },
+    {
+      name: 'Iron Legionary',
+      profiles: [buildProfile(true, 1, 2, 3, 1, 3)],
+    },
+    {
+      name: 'Iron Legionary (Twin Hammers)',
+      profiles: [buildProfile(true, 1, 3, 3, 1, 3)],
+    },
+    {
+      name: 'Iron Legionary (Bolas)',
+      profiles: [buildProfile(false, 3, 3, 3, 1, 2), buildProfile(true, 1, 2, 3, 1, 3)],
+    },
+  ],
+};
+
+export default IronGolems;

--- a/client/src/warbands/UntamedBeasts.ts
+++ b/client/src/warbands/UntamedBeasts.ts
@@ -1,0 +1,40 @@
+import { buildProfile } from './utils';
+import { IWarband } from './warbands.types';
+
+const UntamedBeasts: IWarband = {
+  name: 'Untamed Beasts',
+  alliance: 'Chaos',
+  isAos: false,
+  fighters: [
+    {
+      name: 'Heart Eater',
+      profiles: [buildProfile(true, 1, 4, 4, 2, 5)],
+    },
+    {
+      name: 'First Fang',
+      profiles: [buildProfile(true, 8, 2, 4, 2, 5), buildProfile(false, 1, 3, 4, 1, 4)],
+    },
+    {
+      name: 'Beastspeaker',
+      profiles: [buildProfile(false, 4, 4, 4, 1, 2), buildProfile(true, 1, 3, 4, 1, 4)],
+    },
+    {
+      name: 'Rocktucsk Prowler',
+      profiles: [buildProfile(true, 1, 4, 4, 2, 5)],
+    },
+    {
+      name: 'Preytaker (Sword)',
+      profiles: [buildProfile(true, 1, 4, 3, 2, 4)],
+    },
+    {
+      name: 'Preytaker (Axe)',
+      profiles: [buildProfile(true, 1, 3, 4, 2, 4)],
+    },
+    {
+      name: 'Plains-runner',
+      profiles: [buildProfile(true, 1, 3, 3, 1, 3)],
+    },
+  ],
+};
+
+export default UntamedBeasts;

--- a/client/src/warbands/index.ts
+++ b/client/src/warbands/index.ts
@@ -1,0 +1,6 @@
+import IronGolems from './IronGolems';
+import { IWarband } from './warbands.types';
+
+const warbands: IWarband[] = [IronGolems];
+
+export default warbands;

--- a/client/src/warbands/index.ts
+++ b/client/src/warbands/index.ts
@@ -1,6 +1,7 @@
 import IronGolems from './IronGolems';
+import UntamedBeasts from './UntamedBeasts';
 import { IWarband } from './warbands.types';
 
-const warbands: IWarband[] = [IronGolems];
+const warbands: IWarband[] = [IronGolems, UntamedBeasts];
 
 export default warbands;

--- a/client/src/warbands/utils.ts
+++ b/client/src/warbands/utils.ts
@@ -1,0 +1,16 @@
+import { IProfile } from 'types/fighter';
+
+export const buildProfile = (
+  active: boolean,
+  range: number | string,
+  attacks: number,
+  strength: number,
+  hit: number,
+  crit: number,
+): IProfile => ({
+  active,
+  range,
+  attacks,
+  strength,
+  damage: { hit, crit },
+});

--- a/client/src/warbands/warbands.types.ts
+++ b/client/src/warbands/warbands.types.ts
@@ -1,0 +1,10 @@
+import { IFighter } from 'types/fighter';
+
+export type TAlliance = 'Chaos' | 'Death' | 'Desctruction' | 'Order';
+
+export interface IWarband {
+  name: string;
+  alliance: TAlliance;
+  isAos: boolean;
+  fighters: IFighter[];
+}

--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
         "*",
         "."
     ],
-    "version": "0.1.1",
+    "version": "0.2.0",
     "npmClient": "yarn"
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "dev": "concurrently --kill-others-on-fail \"yarn server\" \"yarn client\"",
         "start": "babel-node server.ts --extensions \".ts,.tsx\"",
         "heroku-postbuild": "cd client && yarn install && yarn install --only=dev --no-shrinkwrap && yarn run build",
-        "test": "jest",
+        "test": "jest api && cd client && yarn test --watchAll=false",
         "bumpversion": "lerna version --no-git-tag-version --no-push",
         "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
         "clean-setup": "rm -rf node_modules && rm -rf client/node_modules && yarn setup"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "@babel/preset-react": "^7.7.4",
         "@babel/preset-typescript": "^7.7.7",
         "@babel/register": "^7.7.4",
+        "@sentry/node": "5.11.2",
         "@types/body-parser": "^1.17.1",
         "@types/compression": "^1.0.1",
         "@types/express": "^4.17.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "body-parser": "^1.18.3",
         "compression": "^1.7.4",
         "concurrently": "^4.0.1",
-        "core-js": "^3.5.0",
+        "core-js": "^3.6.4",
         "eslint": "^6.8.0",
         "eslint-config-airbnb": "^18.0.1",
         "eslint-config-prettier": "^6.9.0",
@@ -61,6 +61,7 @@
         "js-combinatorics": "^0.5.5",
         "lerna": "^3.20.2",
         "prettier": "^1.19.1",
+        "regenerator-runtime": "^0.13.3",
         "typescript": "^3.7.5"
     }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "@babel/preset-react": "^7.7.4",
         "@babel/preset-typescript": "^7.7.7",
         "@babel/register": "^7.7.4",
-        "@sentry/node": "5.11.2",
+        "@sentry/node": "5.12.0",
         "@types/body-parser": "^1.17.1",
         "@types/compression": "^1.0.1",
         "@types/express": "^4.17.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "warcy-statshammer",
     "private": true,
-    "version": "0.1.1",
+    "version": "0.2.0",
     "engines": {
         "node": "12.13.1",
         "yarn": "1.19.2"

--- a/server.ts
+++ b/server.ts
@@ -1,3 +1,6 @@
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
+
 import Sentry from '@sentry/node';
 import bodyParser from 'body-parser';
 import cluster from 'cluster';

--- a/server.ts
+++ b/server.ts
@@ -1,7 +1,7 @@
 import 'core-js/stable';
 import 'regenerator-runtime/runtime';
 
-import Sentry from '@sentry/node';
+import * as Sentry from '@sentry/node';
 import bodyParser from 'body-parser';
 import cluster from 'cluster';
 import express, { Response } from 'express';
@@ -49,6 +49,7 @@ function appServer(production = false) {
       res.sendFile(path.join(__dirname, 'client/build', 'index.html'));
     });
 
+    app.use(Sentry.Handlers.errorHandler());
     logMessage = `Worker ${cluster.worker.id}, ${logMessage}`;
   }
 

--- a/server.ts
+++ b/server.ts
@@ -1,3 +1,4 @@
+import Sentry from '@sentry/node';
 import bodyParser from 'body-parser';
 import cluster from 'cluster';
 import express, { Response } from 'express';
@@ -18,6 +19,10 @@ function appServer(production = false) {
 
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({ extended: true }));
+  if (production) {
+    Sentry.init({ dsn: 'https://b489c4cd314f4966a92689fab89f2e32@sentry.io/2217470' });
+    app.use(Sentry.Handlers.requestHandler());
+  }
 
   app.get('/status', (req, res) => {
     addHeaders(res, production);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1917,6 +1917,85 @@
   dependencies:
     "@types/node" ">= 8"
 
+"@sentry/apm@5.11.2":
+  version "5.11.2"
+  resolved "https://registry.yarnpkg.com/@sentry/apm/-/apm-5.11.2.tgz#35961b9d2319ad21ae91f1b697998a8c523f1919"
+  integrity sha512-qn4HiSZ+6b1Gg+DlXdHVpiPPEbRu4IicGSbI8HTJLzrlsjoaBQPPkDwtuQUBVq21tU3RYXnTwrl9m45KuX6alA==
+  dependencies:
+    "@sentry/browser" "5.11.2"
+    "@sentry/hub" "5.11.2"
+    "@sentry/minimal" "5.11.2"
+    "@sentry/types" "5.11.0"
+    "@sentry/utils" "5.11.1"
+    tslib "^1.9.3"
+
+"@sentry/browser@5.11.2":
+  version "5.11.2"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.11.2.tgz#f0b19bd97e9f09a20e9f93a9835339ed9ab1f5a4"
+  integrity sha512-ls6ARX5m+23ld8OsuoPnR+kehjR5ketYWRcDYlmJDX2VOq5K4EzprujAo8waDB0o5a92yLXQ0ZSoK/zzAV2VoA==
+  dependencies:
+    "@sentry/core" "5.11.2"
+    "@sentry/types" "5.11.0"
+    "@sentry/utils" "5.11.1"
+    tslib "^1.9.3"
+
+"@sentry/core@5.11.2":
+  version "5.11.2"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.11.2.tgz#f2d9d37940d291dbcb9a9e4a012f76919474bdf6"
+  integrity sha512-IFCXGy7ebqIq/Kb8RVryCo/SjwhPcrfBmOjkicr4+DxN1UybLre2N3p9bejQMPIteOfDVHlySLYeipjTf+mxZw==
+  dependencies:
+    "@sentry/hub" "5.11.2"
+    "@sentry/minimal" "5.11.2"
+    "@sentry/types" "5.11.0"
+    "@sentry/utils" "5.11.1"
+    tslib "^1.9.3"
+
+"@sentry/hub@5.11.2":
+  version "5.11.2"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.11.2.tgz#a3b7ec27cd4cea2cddd75c372fbf1b4bc04c6aae"
+  integrity sha512-5BiDin6ZPsaiTm29rCC41MAjP1vOaKniqfjtXHVPm7FeOBA2bpHm95ncjLkshKGJTPfPZHXTpX/1IZsHrfGVEA==
+  dependencies:
+    "@sentry/types" "5.11.0"
+    "@sentry/utils" "5.11.1"
+    tslib "^1.9.3"
+
+"@sentry/minimal@5.11.2":
+  version "5.11.2"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.11.2.tgz#ae417699342266ecd109a97e53cd9519c0893b21"
+  integrity sha512-oNuJuz3EZhVtamzABmPdr6lcYo06XHLWb2LvgnoNaYcMD1ExUSvhepOSyZ2h5STCMbmVgGVfXBNPV9RUTp8GZg==
+  dependencies:
+    "@sentry/hub" "5.11.2"
+    "@sentry/types" "5.11.0"
+    tslib "^1.9.3"
+
+"@sentry/node@5.11.2":
+  version "5.11.2"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-5.11.2.tgz#575c320b624c218d2155183f6bbe82b732bfb1f2"
+  integrity sha512-jYq9u76BdAbOKPuYg39Xh/+797MevzjMkCIC9cw/bQxAm6nHc3FXeKqd79O33jO4Jag0JL+Bz/0JidgrKgKgXg==
+  dependencies:
+    "@sentry/apm" "5.11.2"
+    "@sentry/core" "5.11.2"
+    "@sentry/hub" "5.11.2"
+    "@sentry/types" "5.11.0"
+    "@sentry/utils" "5.11.1"
+    cookie "^0.3.1"
+    https-proxy-agent "^4.0.0"
+    lru_map "^0.3.3"
+    tslib "^1.9.3"
+
+"@sentry/types@5.11.0":
+  version "5.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.11.0.tgz#40f0f3174362928e033ddd9725d55e7c5cb7c5b6"
+  integrity sha512-1Uhycpmeo1ZK2GLvrtwZhTwIodJHcyIS6bn+t4IMkN9MFoo6ktbAfhvexBDW/IDtdLlCGJbfm8nIZerxy0QUpg==
+
+"@sentry/utils@5.11.1":
+  version "5.11.1"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.11.1.tgz#aa19fcc234cf632257b2281261651d2fac967607"
+  integrity sha512-O0Zl4R2JJh8cTkQ8ZL2cDqGCmQdpA5VeXpuBbEl1v78LQPkBDISi35wH4mKmLwMsLBtTVpx2UeUHBj0KO5aLlA==
+  dependencies:
+    "@sentry/types" "5.11.0"
+    tslib "^1.9.3"
+
 "@sinonjs/commons@^1.7.0":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.0.tgz#f90ffc52a2e519f018b13b6c4da03cbff36ebed6"
@@ -2225,6 +2304,11 @@ agent-base@4, agent-base@^4.3.0:
   integrity sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==
   dependencies:
     es6-promisify "^5.0.0"
+
+agent-base@5:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
+  integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
 
 agent-base@~4.2.1:
   version "4.2.1"
@@ -3262,6 +3346,11 @@ cookie@0.4.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
 
+cookie@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
+  integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
+
 copy-concurrently@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/copy-concurrently/-/copy-concurrently-1.0.5.tgz#92297398cae34937fcafd6ec8139c18051f0b5e0"
@@ -3413,17 +3502,17 @@ debug@3.1.0:
   dependencies:
     ms "2.0.0"
 
+debug@4, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
 debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
-  dependencies:
-    ms "^2.1.1"
-
-debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
@@ -4779,6 +4868,14 @@ https-proxy-agent@^2.2.3:
     agent-base "^4.3.0"
     debug "^3.1.0"
 
+https-proxy-agent@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz#702b71fb5520a132a66de1f67541d9e62154d82b"
+  integrity sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==
+  dependencies:
+    agent-base "5"
+    debug "4"
+
 human-signals@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
@@ -6020,6 +6117,11 @@ lru-cache@^5.1.1:
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
     yallist "^3.0.2"
+
+lru_map@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/lru_map/-/lru_map-0.3.3.tgz#b5c8351b9464cbd750335a79650a0ec0e56118dd"
+  integrity sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0=
 
 macos-release@^2.2.0:
   version "2.3.0"
@@ -8545,7 +8647,7 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3381,7 +3381,7 @@ core-js-pure@^3.0.0:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.4.tgz#4bf1ba866e25814f149d4e9aaa08c36173506e3a"
   integrity sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw==
 
-core-js@^3.2.1, core-js@^3.5.0:
+core-js@^3.2.1, core-js@^3.6.4:
   version "3.6.4"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.4.tgz#440a83536b458114b9cb2ac1580ba377dc470647"
   integrity sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1917,83 +1917,83 @@
   dependencies:
     "@types/node" ">= 8"
 
-"@sentry/apm@5.11.2":
-  version "5.11.2"
-  resolved "https://registry.yarnpkg.com/@sentry/apm/-/apm-5.11.2.tgz#35961b9d2319ad21ae91f1b697998a8c523f1919"
-  integrity sha512-qn4HiSZ+6b1Gg+DlXdHVpiPPEbRu4IicGSbI8HTJLzrlsjoaBQPPkDwtuQUBVq21tU3RYXnTwrl9m45KuX6alA==
+"@sentry/apm@5.12.0":
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/@sentry/apm/-/apm-5.12.0.tgz#6ec9c11d2754ab597bd0752b55fbbf2537f1d96b"
+  integrity sha512-tpD6c0dVKkG+QPEubTTr54TDFdR/FWldnHwkhq4CST2uwkEm26o95iuNhMx9WE7EJhpXjaFKpZB0TB8frFIqkg==
   dependencies:
-    "@sentry/browser" "5.11.2"
-    "@sentry/hub" "5.11.2"
-    "@sentry/minimal" "5.11.2"
-    "@sentry/types" "5.11.0"
-    "@sentry/utils" "5.11.1"
+    "@sentry/browser" "5.12.0"
+    "@sentry/hub" "5.12.0"
+    "@sentry/minimal" "5.12.0"
+    "@sentry/types" "5.12.0"
+    "@sentry/utils" "5.12.0"
     tslib "^1.9.3"
 
-"@sentry/browser@5.11.2":
-  version "5.11.2"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.11.2.tgz#f0b19bd97e9f09a20e9f93a9835339ed9ab1f5a4"
-  integrity sha512-ls6ARX5m+23ld8OsuoPnR+kehjR5ketYWRcDYlmJDX2VOq5K4EzprujAo8waDB0o5a92yLXQ0ZSoK/zzAV2VoA==
+"@sentry/browser@5.12.0":
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.12.0.tgz#d2c5b683eca6d5489a2c5b237712a8c9de9d4427"
+  integrity sha512-e8uQML/1Wz2A6610yEvTdICf7L2IH15z6kcjwEqTsaD5uBCmpCiebGZABb45OSe9u8J0xccqi5G7M8lcxj1L7w==
   dependencies:
-    "@sentry/core" "5.11.2"
-    "@sentry/types" "5.11.0"
-    "@sentry/utils" "5.11.1"
+    "@sentry/core" "5.12.0"
+    "@sentry/types" "5.12.0"
+    "@sentry/utils" "5.12.0"
     tslib "^1.9.3"
 
-"@sentry/core@5.11.2":
-  version "5.11.2"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.11.2.tgz#f2d9d37940d291dbcb9a9e4a012f76919474bdf6"
-  integrity sha512-IFCXGy7ebqIq/Kb8RVryCo/SjwhPcrfBmOjkicr4+DxN1UybLre2N3p9bejQMPIteOfDVHlySLYeipjTf+mxZw==
+"@sentry/core@5.12.0":
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.12.0.tgz#d6380c4ef7beee5f418ac1d0e5be86a2de2af449"
+  integrity sha512-wY4rsoX71QsGpcs9tF+OxKgDPKzIFMRvFiSRcJoPMfhFsTilQ/CBMn/c3bDtWQd9Bnr/ReQIL6NbnIjUsPHA4Q==
   dependencies:
-    "@sentry/hub" "5.11.2"
-    "@sentry/minimal" "5.11.2"
-    "@sentry/types" "5.11.0"
-    "@sentry/utils" "5.11.1"
+    "@sentry/hub" "5.12.0"
+    "@sentry/minimal" "5.12.0"
+    "@sentry/types" "5.12.0"
+    "@sentry/utils" "5.12.0"
     tslib "^1.9.3"
 
-"@sentry/hub@5.11.2":
-  version "5.11.2"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.11.2.tgz#a3b7ec27cd4cea2cddd75c372fbf1b4bc04c6aae"
-  integrity sha512-5BiDin6ZPsaiTm29rCC41MAjP1vOaKniqfjtXHVPm7FeOBA2bpHm95ncjLkshKGJTPfPZHXTpX/1IZsHrfGVEA==
+"@sentry/hub@5.12.0":
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.12.0.tgz#5e8c8f249f5bdbeb8cc4ec02c2ccc53a67f2cc02"
+  integrity sha512-3k7yE8BEVJsKx8mR4LcI4IN0O8pngmq44OcJ/fRUUBAPqsT38jsJdP2CaWhdlM1jiNUzUDB1ktBv6/lY+VgcoQ==
   dependencies:
-    "@sentry/types" "5.11.0"
-    "@sentry/utils" "5.11.1"
+    "@sentry/types" "5.12.0"
+    "@sentry/utils" "5.12.0"
     tslib "^1.9.3"
 
-"@sentry/minimal@5.11.2":
-  version "5.11.2"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.11.2.tgz#ae417699342266ecd109a97e53cd9519c0893b21"
-  integrity sha512-oNuJuz3EZhVtamzABmPdr6lcYo06XHLWb2LvgnoNaYcMD1ExUSvhepOSyZ2h5STCMbmVgGVfXBNPV9RUTp8GZg==
+"@sentry/minimal@5.12.0":
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.12.0.tgz#2611e2aa520c1edb7999e6de51bd65ec66341757"
+  integrity sha512-fk73meyz4k4jCg9yzbma+WkggsfEIQWI2e2TWfYsRGcrV3RnlSrXyM4D91/A8Bjx10SNezHPUFHjasjlHXOkyA==
   dependencies:
-    "@sentry/hub" "5.11.2"
-    "@sentry/types" "5.11.0"
+    "@sentry/hub" "5.12.0"
+    "@sentry/types" "5.12.0"
     tslib "^1.9.3"
 
-"@sentry/node@5.11.2":
-  version "5.11.2"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-5.11.2.tgz#575c320b624c218d2155183f6bbe82b732bfb1f2"
-  integrity sha512-jYq9u76BdAbOKPuYg39Xh/+797MevzjMkCIC9cw/bQxAm6nHc3FXeKqd79O33jO4Jag0JL+Bz/0JidgrKgKgXg==
+"@sentry/node@5.12.0":
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-5.12.0.tgz#9781d3cf4d7f664acacb9775912f67a3a465c259"
+  integrity sha512-Q059wrvv7JDTfdlnI4GCAOW9BLeRxxx8P+TYK/t41ZgEbwTob/VU+rn+p7zQm8beHMM3IBtUKE54AmpHYnhJ/A==
   dependencies:
-    "@sentry/apm" "5.11.2"
-    "@sentry/core" "5.11.2"
-    "@sentry/hub" "5.11.2"
-    "@sentry/types" "5.11.0"
-    "@sentry/utils" "5.11.1"
+    "@sentry/apm" "5.12.0"
+    "@sentry/core" "5.12.0"
+    "@sentry/hub" "5.12.0"
+    "@sentry/types" "5.12.0"
+    "@sentry/utils" "5.12.0"
     cookie "^0.3.1"
     https-proxy-agent "^4.0.0"
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
-"@sentry/types@5.11.0":
-  version "5.11.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.11.0.tgz#40f0f3174362928e033ddd9725d55e7c5cb7c5b6"
-  integrity sha512-1Uhycpmeo1ZK2GLvrtwZhTwIodJHcyIS6bn+t4IMkN9MFoo6ktbAfhvexBDW/IDtdLlCGJbfm8nIZerxy0QUpg==
+"@sentry/types@5.12.0":
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.12.0.tgz#5367e53c74261beea01502e3f7b6f3d822682a31"
+  integrity sha512-aZbBouBLrKB8wXlztriIagZNmsB+wegk1Jkl6eprqRW/w24Sl/47tiwH8c5S4jYTxdAiJk+SAR10AAuYmIN3zg==
 
-"@sentry/utils@5.11.1":
-  version "5.11.1"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.11.1.tgz#aa19fcc234cf632257b2281261651d2fac967607"
-  integrity sha512-O0Zl4R2JJh8cTkQ8ZL2cDqGCmQdpA5VeXpuBbEl1v78LQPkBDISi35wH4mKmLwMsLBtTVpx2UeUHBj0KO5aLlA==
+"@sentry/utils@5.12.0":
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.12.0.tgz#62967f934a3ee6d21472eac0219084e37225933e"
+  integrity sha512-fYUadGLbfTCbs4OG5hKCOtv2jrNE4/8LHNABy9DwNJ/t5DVtGqWAZBnxsC+FG6a3nVqCpxjFI9AHlYsJ2wsf7Q==
   dependencies:
-    "@sentry/types" "5.11.0"
+    "@sentry/types" "5.12.0"
     tslib "^1.9.3"
 
 "@sinonjs/commons@^1.7.0":


### PR DESCRIPTION
## UI

- The Left Navigation Bar on Desktop has been revamped and will no longer scroll with the content.

## API

- Instead of generating data per toughness, instead build `lt`, `eq`, `gt` properties. Then map that to the different toughness values (Fixes: https://github.com/damonhook/warcry-statshammer/issues/13)
    - This should have no difference in the final result, however, should improve performance greatly
- If you try and generate data for attacks > 8, switch to a simulation of dice rolls rather than generating every permutation (Fixes: https://github.com/damonhook/warcry-statshammer/issues/13)
- Added Sentry to API to capture errors (Fixes: https://github.com/damonhook/warcry-statshammer/issues/11)

## Notes
Here is a table of the number of permutations as the attacks grow:

| Attacks | Permutations  |
|---------|---------------|
| 2       | 36            |
| 4       | 1 296         |
| 6       | 46 656        |
| 8       | 1 679 616     |
| 10      | 60 466 176    |
| 12      | 2 176 782 336 |

Because of this it becomes too expensive to get population permutations for attacks > 8. Hence why it switches over to doing `1 500 000` simulations instead. It should be accurate enough as the probabilities are limited to 2 dec. places on the UI anyway